### PR TITLE
Make assets.yml compatible with OroAssetBundle

### DIFF
--- a/Resources/config/oro/assets.yml
+++ b/Resources/config/oro/assets.yml
@@ -1,4 +1,3 @@
-assets:
-    css:
-      'oromailchimp':
-          - 'bundles/oromailchimp/css/styles.css'
+css:
+    inputs:
+        - 'bundles/oromailchimp/css/styles.css'


### PR DESCRIPTION
OroPlatform 3.1 uses OroAsseticBundle for assets. To accomodate this, the file `Resources/oro/assets.yml` has to be changed, the file tagged 1.0.0 causes errors when compiling assets.

See https://github.com/oroinc/platform/blob/master/src/Oro/Bundle/AssetBundle/Resources/doc/index.md