### PR TITLE
Update parent class in DI definition for oro 3.1.9 compatibility

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -648,7 +648,7 @@ services:
 
     oro_mailchimp.importexport.strategy.member_activity:
         class: '%oro_mailchimp.importexport.strategy.member_activity.class%'
-        parent: oro_importexport.strategy.configurable_add_or_replace
+        parent: oro_importexport.strategy.abstract_import_strategy
         calls:
             - [setLogger, ["@oro_integration.logger.strategy"]]
 


### PR DESCRIPTION
* Wrong parent class in services.yml for oro_mailchimp.importexport.strategy.member_activity breaks all imports for oro platform 3.1.9.
* To fix parent classe replaced with oro_importexport.strategy.abstract_import_strategy
* Old parent class oro_importexport.strategy.configurable_add_or_replace is not the correct one, an update adding a call to setRelatedEntityStateHelper introduces the issue.
See Commit: https://github.com/oroinc/platform/commit/41c643830fa155233fda8273f4a87b3719a4eec1 (stategy.yml line 50-51)